### PR TITLE
Fix rapido a la carta de los vehiculos

### DIFF
--- a/Vista/wwwroot/css/Unidades.css
+++ b/Vista/wwwroot/css/Unidades.css
@@ -266,3 +266,24 @@ button.ant-btn-primary {
     color: white !important;
 
 }
+
+
+
+.vehiculo-imagen-contenedor {
+    height: 200px;
+    width: 100%;
+    object-fit: cover;
+    border-radius: 8px;
+}
+
+.vehiculo-info {
+    flex-grow: 1;
+    margin-top: 10px;
+}
+
+.vehiculo-botones {
+    display: flex;
+    justify-content: space-between;
+    gap: 6px;
+    margin-top: 10px;
+}


### PR DESCRIPTION
Se arreglo un poco los botones para que la imagen no afecte el tamaño de la carta de los vehiculos. ESPERO que esta vez no se rompa todo. Despues organizare todo el vista.css para que los que sigan despues de nosotros no se encuentren todo desordenado.