### PR TITLE
Errores de Null en Pagina Reportes

### DIFF
--- a/FireForce.Client/Pages/Reportes/HistorialBomberos.razor
+++ b/FireForce.Client/Pages/Reportes/HistorialBomberos.razor
@@ -427,9 +427,9 @@
                 Nombre = a.Nombre,
                 Apellido = a.Apellido,
                 Grado = a.Grado,
-                TelefonoCel = contacto.TelefonoCel,
-                TelefonoLaboral = contacto.TelefonoLaboral,
-                Email = contacto.Email
+                TelefonoCel = contacto?.TelefonoCel,
+                TelefonoLaboral = contacto?.TelefonoLaboral,
+                Email = contacto?.Email
             };
             BomberosVM.Add(Bm);
         }

--- a/FireForce.Client/Pages/Reportes/Info_Chofers.razor
+++ b/FireForce.Client/Pages/Reportes/Info_Chofers.razor
@@ -471,8 +471,8 @@
                 DotacionNumero = (int)chofer.Dotacion,
                 VencimientoRegistro = chofer.VencimientoRegistro,
                 NumeroLegajo = chofer.NumeroLegajo,
-                TelefonoCel = contactos.TelefonoCel,
-                TelefonoLaboral = contactos.TelefonoLaboral
+                TelefonoCel = contactos?.TelefonoCel,
+                TelefonoLaboral = contactos?.TelefonoLaboral
             };
 
             b.Add(ChoferesPasajeVM);


### PR DESCRIPTION
Segun lo consultado con el cliente, el apartado de "contacto" podria quedar vacio para los bomberos, lo que provocaria error en el apartado de Reportes ya que no cuentan con valores nulleables.